### PR TITLE
fix: Ruby バージョンの不整合を修正

### DIFF
--- a/kansai_train_info.gemspec
+++ b/kansai_train_info.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'check train info in kansai area'
   spec.description   = 'you can check train info in kansai area'
   spec.license       = 'MIT'
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.3.0')
+  spec.required_ruby_version = Gem::Requirement.new('>= 3.0.0')
 
   # Specify which files should be added to the gem when it is released.
   spec.files         = Dir['lib/**/*.rb'] + ['README.md', 'LICENSE.txt']


### PR DESCRIPTION
## 概要
gemspecのRubyバージョン要件をREADMEおよびCircleCI設定と一致させました。

## 変更内容
- :  を  から  に更新

## 関連Issue
Fixes #13

## 影響
- Ruby 2.x系のサポートを終了します
- Ruby 3.0.0以上が必須となります

🤖 Generated with Claude Code